### PR TITLE
Allow multiple selected osm obj ids to be copied to the clipboard

### DIFF
--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
@@ -3,8 +3,12 @@ package org.openstreetmap.josm.plugins.osmobjinfo;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
+import java.util.List;
+
 import javax.swing.JOptionPane;
 import org.openstreetmap.josm.gui.Notification;
+import org.openstreetmap.josm.plugins.osmobjinfo.OSMObjInfotDialog.AllOsmObjInfo;
+
 import static org.openstreetmap.josm.tools.I18n.tr;
 import org.openstreetmap.josm.tools.OpenBrowser;
 
@@ -13,21 +17,23 @@ import org.openstreetmap.josm.tools.OpenBrowser;
  * @author ruben
  */
 public class OSMObjInfoActions {
+    public static final String COPY = "Copy: {0}";
+    public static final String OPEN_IN_BROWSER = "Open in browser {0}";
 
     public static void copyUser(String user) {
         if (!user.isEmpty()) {
-            String linkUser = "http://www.openstreetmap.org/user/" + user;
+            String linkUser = "http://www.openstreetmap.org/user/".concat(user);
             StringSelection selection = new StringSelection(linkUser);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             clipboard.setContents(selection, selection);
-            new Notification(tr("Copy: " + linkUser)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            new Notification(tr(COPY, linkUser)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
         }
     }
 
     public static void openinBrowserUser(String user) {
         if (!user.isEmpty()) {
-            String url = "http://www.openstreetmap.org/user/" + user;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            String url = "http://www.openstreetmap.org/user/".concat(user);
+            new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
             OpenBrowser.displayUrl(url);
         }
 
@@ -35,69 +41,92 @@ public class OSMObjInfoActions {
 
     public static void openinBrowserUserNeis(String user) {
         if (!user.isEmpty()) {
-            String url = "http://hdyc.neis-one.org/?" + user;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            String url = "http://hdyc.neis-one.org/?".concat(user);
+            new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
             OpenBrowser.displayUrl(url);
         }
     }
 
     static void openinBrowserUserOsmComments(String user) {
         if (!user.isEmpty()) {
-            String url = "https://www.mapbox.com/osm-comments/#/changesets/?q=users:" + user;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            String url = "https://www.mapbox.com/osm-comments/#/changesets/?q=users:".concat(user);
+            new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
             OpenBrowser.displayUrl(url);
         }
     }
 
     public static void copyChangeset(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            String linkchangeset = "https://www.openstreetmap.org/changeset/" + idChangeset;
+            String linkchangeset = "https://www.openstreetmap.org/changeset/".concat(idChangeset);
             StringSelection selection = new StringSelection(linkchangeset);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             clipboard.setContents(selection, selection);
-            new Notification(tr("Copy: " + linkchangeset)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            new Notification(tr(COPY, linkchangeset)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
         }
     }
 
     public static void openinBrowserChangeset(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            String url = "https://www.openstreetmap.org/changeset/" + idChangeset;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            String url = "https://www.openstreetmap.org/changeset/".concat(idChangeset);
+            new Notification(tr(COPY, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
             OpenBrowser.displayUrl(url);
         }
     }
 
     public static void openinBrowserChangesetMap(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            String url = "https://osmcha.mapbox.com/" + idChangeset;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            String url = "https://osmcha.mapbox.com/".concat(idChangeset);
+            new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
             OpenBrowser.displayUrl(url);
         }
     }
 
-    public static void copyIdobj(String typeObj, String idobj) {
-        if (typeObj != null && !idobj.isEmpty()) {
-            String linkobjid = "https://www.openstreetmap.org/" + typeObj + "/" + idobj;
-            StringSelection selection = new StringSelection(linkobjid);
-            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(selection, selection);
-            new Notification(tr("Copy: " + linkobjid)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+    public static void copyIdobj(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo == null || osmObjInfo.isEmpty()) return;
+        String linkobjid = "";
+        StringBuilder builder = new StringBuilder();
+        for (AllOsmObjInfo object : osmObjInfo) {
+            builder.append("https://www.openstreetmap.org/")
+                .append(object.typeObj).append("/").append(object.idObject);
+            if (osmObjInfo.indexOf(object) < osmObjInfo.size() - 2) {
+                builder.append(", ");
+            }
+            if (osmObjInfo.indexOf(object) == osmObjInfo.size() - 2) {
+                if (osmObjInfo.size() == 2) {
+                    builder.append(" ");
+                } else {
+                    builder.append(", ");
+                }
+                builder.append(tr("and"));
+                builder.append(" ");
+            }
+        }
+        linkobjid = builder.toString();
+        StringSelection selection = new StringSelection(linkobjid);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(selection, selection);
+        new Notification(tr(COPY, linkobjid)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+    }
+
+    public static void openinBrowserIdobj(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo.size() > 5 || osmObjInfo.isEmpty()) return;
+        for (AllOsmObjInfo info : osmObjInfo) {
+            if (info.typeObj != null && !info.idObject.isEmpty()) {
+                String url = "https://www.openstreetmap.org/" + info.typeObj + "/" + info.idObject;
+                new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+                OpenBrowser.displayUrl(url);
+            }
         }
     }
 
-    public static void openinBrowserIdobj(String typeObj, String idobj) {
-        if (typeObj != null && !idobj.isEmpty()) {
-            String url = "https://www.openstreetmap.org/" + typeObj + "/" + idobj;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
-            OpenBrowser.displayUrl(url);
-        }
-    }
-
-    public static void openinBrowserIdobjOsmDeepHistory(String typeObj, String idobj) {
-        if (typeObj != null && !idobj.isEmpty()) {
-            String url = "http://osmlab.github.io/osm-deep-history/#/" + typeObj + "/" + idobj;
-            new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
-            OpenBrowser.displayUrl(url);
+    public static void openinBrowserIdobjOsmDeepHistory(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo.size() > 5 || osmObjInfo.isEmpty()) return;
+        for (AllOsmObjInfo info : osmObjInfo) {
+            if (info.typeObj != null && !info.idObject.isEmpty()) {
+                String url = "http://osmlab.github.io/osm-deep-history/#/" + info.typeObj + "/" + info.idObject;
+                new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+                OpenBrowser.displayUrl(url);
+            }
         }
     }
 
@@ -105,7 +134,7 @@ public class OSMObjInfoActions {
         if (coords == null || coords.isEmpty()) return;
         String[] arrCoords = coords.split(",");
         String url = "https://www.mapillary.com/app/?lat=" + arrCoords[0] + "&lng=" + arrCoords[1] + "&z=20&focus=map&dateFrom=2017-01-01";
-        new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+        new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
         OpenBrowser.displayUrl(url);
 
     }
@@ -114,7 +143,7 @@ public class OSMObjInfoActions {
         if (coords == null || coords.isEmpty()) return;
         String[] arrCoords = coords.split(",");
         String url = "http://openstreetcam.org/map/@" + arrCoords[0] + "," + arrCoords[1] + ",18z";
-        new Notification(tr("Open in browser " + url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+        new Notification(tr(OPEN_IN_BROWSER, url)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
         OpenBrowser.displayUrl(url);
     }
 

--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfotDialog.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfotDialog.java
@@ -13,8 +13,10 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -57,13 +59,17 @@ public class OSMObjInfotDialog extends ToggleDialog {
     protected JLabel lbMapillary;
     protected JLabel lbOsmcamp;
 
-    String typeObj;
-    String user = "";
-    String version = "";
-    String idObject = "";
-    String timestamp = "";
-    String idchangeset = "";
-    String coordinates = "";
+    List<AllOsmObjInfo> allSelectedObjInfo;
+
+    public class AllOsmObjInfo {
+        String typeObj;
+        String user = "";
+        String version = "";
+        String idObject = "";
+        String timestamp = "";
+        String idchangeset = "";
+        String coordinates = "";
+    }
 
     public OSMObjInfotDialog() {
         super(tr("OpenStreetMap obj info"),
@@ -71,6 +77,8 @@ public class OSMObjInfotDialog extends ToggleDialog {
                 tr("Open OpenStreetMap obj info window"),
                 Shortcut.registerShortcut("osmObjInfo", tr("Toggle: {0}", tr("OpenStreetMap obj info")), KeyEvent.VK_I, Shortcut.ALT_CTRL_SHIFT), 90);
 
+        allSelectedObjInfo = new ArrayList<>();
+        allSelectedObjInfo.add(new AllOsmObjInfo());
         JPanel panel = new JPanel(new GridLayout(0, 2));
         panel.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         //user
@@ -231,7 +239,7 @@ public class OSMObjInfotDialog extends ToggleDialog {
 
     private JPanel buildidObject() {
 
-        //OBJ ID 
+        //OBJ ID
         JPanel jpIdobj = new JPanel(new BorderLayout());
 
         lbIdobj = new JLabel();
@@ -251,77 +259,73 @@ public class OSMObjInfotDialog extends ToggleDialog {
         jpIdobj.add(lbIdobj, BorderLayout.LINE_START);
         jpIdobj.add(jpIdobjOptions, BorderLayout.LINE_END);
 
-        //id obj actions 
+        //id obj actions
         lbLinnkIdobj.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                OSMObjInfoActions.openinBrowserIdobj(typeObj, lbIdobj.getText());
+                OSMObjInfoActions.openinBrowserIdobj(allSelectedObjInfo);
             }
         });
         lbCopyIdobj.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                OSMObjInfoActions.copyIdobj(typeObj, lbIdobj.getText());
+                OSMObjInfoActions.copyIdobj(allSelectedObjInfo);
             }
         });
 
         lbOsmDeepHistory.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
-                OSMObjInfoActions.openinBrowserIdobjOsmDeepHistory(typeObj, lbIdobj.getText());
+                OSMObjInfoActions.openinBrowserIdobjOsmDeepHistory(allSelectedObjInfo);
             }
         });
         return jpIdobj;
     }
 
     public void selection(Collection<? extends OsmPrimitive> selection) {
-        if (selection.size() < 2) {
-            user = "";
-            version = "";
-            idObject = "";
-            timestamp = "";
-            idchangeset = "";
-            coordinates = "";
+        allSelectedObjInfo = new ArrayList<>();
 
-            for (OsmPrimitive element : selection) {
-                if (!element.isNew()) {
-
-                    typeObj = element.getType().toString();
-                    try {
-                        user = element.getUser().getName();
-                        timestamp = new SimpleDateFormat("yyyy/MM/dd hh:mm a").format(element.getTimestamp().getTime());
-                    } catch (NullPointerException e) {
-                        user = UserIdentityManager.getInstance().getUserName();
-                    }
-                    idObject = String.valueOf(element.getId());
-                    version = String.valueOf(element.getVersion());
-                    idchangeset = String.valueOf(element.getChangesetId());
-
-                    DecimalFormat df = new DecimalFormat("#.00000");
-                    coordinates = df.format(element.getBBox().getCenter().lat()) + "," + df.format(element.getBBox().getCenter().lon());
-
+        for (OsmPrimitive element : selection) {
+            if (!element.isNew()) {
+                AllOsmObjInfo info = new AllOsmObjInfo();
+                allSelectedObjInfo.add(info);
+                info.typeObj = element.getType().toString();
+                try {
+                    info.user = element.getUser().getName();
+                    info.timestamp = new SimpleDateFormat("yyyy/MM/dd hh:mm a").format(element.getTimestamp().getTime());
+                } catch (NullPointerException e) {
+                    info.user = UserIdentityManager.getInstance().getUserName();
                 }
+                info.idObject = String.valueOf(element.getId());
+                info.version = String.valueOf(element.getVersion());
+                info.idchangeset = String.valueOf(element.getChangesetId());
+
+                DecimalFormat df = new DecimalFormat("#.00000");
+                info.coordinates = df.format(element.getBBox().getCenter().lat()) + "," + df.format(element.getBBox().getCenter().lon());
             }
-
-            final String txtUser = user;
-            final String txtVersion = version;
-            final String txtIdobject = idObject;
-            final String txtTimestamp = timestamp;
-            final String txtIdChangeset = idchangeset;
-
-            GuiHelper.runInEDT(new Runnable() {
-                @Override
-                public void run() {
-                    lbUser.setText(txtUser);
-                    lbIdChangeset.setText(txtIdChangeset);
-                    lbIdobj.setText(txtIdobject);
-                    lbVersion.setText(txtVersion);
-                    lbTimestamp.setText(txtTimestamp);
-                    lbMapillary.setText(coordinates);
-
-                }
-            });
         }
+        if (allSelectedObjInfo.isEmpty()) allSelectedObjInfo.add(new AllOsmObjInfo());
+
+        AllOsmObjInfo info = allSelectedObjInfo.get(0);
+        final String txtUser = info.user;
+        final String txtVersion = info.version;
+        final String txtIdobject = info.idObject;
+        final String txtTimestamp = info.timestamp;
+        final String txtIdChangeset = info.idchangeset;
+        final String coordinates = info.coordinates;
+
+        GuiHelper.runInEDT(new Runnable() {
+            @Override
+            public void run() {
+                lbUser.setText(txtUser);
+                lbIdChangeset.setText(txtIdChangeset);
+                lbIdobj.setText(txtIdobject);
+                lbVersion.setText(txtVersion);
+                lbTimestamp.setText(txtTimestamp);
+                lbMapillary.setText(coordinates);
+
+            }
+        });
     }
 
     public void getInfoNotes(MouseEvent e) {
@@ -329,16 +333,22 @@ public class OSMObjInfotDialog extends ToggleDialog {
             NoteLayer noteLayer = getLayerManager().getLayersOfType(NoteLayer.class).get(0);
             noteLayer.mouseClicked(e);
             if (!noteLayer.getNoteData().getNotes().isEmpty() && noteLayer.getNoteData().getSelectedNote() != null) {
-                typeObj = "note";
-                lbUser.setText(noteLayer.getNoteData().getSelectedNote().getFirstComment().getUser().getName());
+                allSelectedObjInfo = new ArrayList<>();
+                AllOsmObjInfo info = new AllOsmObjInfo();
+                allSelectedObjInfo.add(info);
+                info.typeObj = "note";
+                info.user = noteLayer.getNoteData().getSelectedNote().getFirstComment().getUser().getName();
+                lbUser.setText(info.user);
                 lbIdChangeset.setText("");
                 if (noteLayer.getNoteData().getSelectedNote().getId() < 0) {
                     lbIdobj.setText("");
                 } else {
-                    lbIdobj.setText(Long.toString(noteLayer.getNoteData().getSelectedNote().getId()));
+                    info.idObject = Long.toString(noteLayer.getNoteData().getSelectedNote().getId());
+                    lbIdobj.setText(info.idObject);
                 }
                 lbVersion.setText("");
-                lbTimestamp.setText(new SimpleDateFormat("yyyy/MM/dd hh:mm a").format(noteLayer.getNoteData().getSelectedNote().getCreatedAt()));
+                info.timestamp = new SimpleDateFormat("yyyy/MM/dd hh:mm a").format(noteLayer.getNoteData().getSelectedNote().getCreatedAt());
+                lbTimestamp.setText(info.timestamp);
             }
         }
     }
@@ -356,7 +366,7 @@ public class OSMObjInfotDialog extends ToggleDialog {
         //add
         jpIMapillary.add(lbMapillary, BorderLayout.LINE_START);
         jpIMapillary.add(jpIMapillaryOptions, BorderLayout.LINE_END);
-        //id obj actions 
+        //id obj actions
         lbLinkMapillary.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {


### PR DESCRIPTION
	* Also refactor OsmObjInfoActions to better use the tr()
	  functionality
	* Allow other open in browser functions to take multiple osm obj
	  ids, but don't do anything if there are more than 4 (to avoid
	  having hundreds of tabs being opened at once)

Signed-off-by: Taylor Smock <taylor.smock@kaartgroup.com>