### PR TITLE
Add remote control copy for objects (works if no objects are selected…

### DIFF
--- a/images/dialogs/remote.svg
+++ b/images/dialogs/remote.svg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="58.208332mm"
+   height="119.0625mm"
+   viewBox="0 0 58.208332 119.0625"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="remote.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.2980372"
+     inkscape:cx="198.21166"
+     inkscape:cy="399.22961"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     showguides="false"
+     inkscape:window-width="2051"
+     inkscape:window-height="1079"
+     inkscape:window-x="1919"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3804"
+       originx="-74.083334"
+       originy="-103.1875" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-74.083336,-74.75)">
+    <rect
+       style="fill:#4d4d4d;stroke-width:0.26458332"
+       id="rect3991"
+       width="58.208332"
+       height="119.0625"
+       x="74.083336"
+       y="74.75" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="rect3989"
+       width="50.270832"
+       height="72.760414"
+       x="79.375"
+       y="80.041664" />
+    <rect
+       style="fill:#666666;stroke-width:0.26458332"
+       id="rect3782"
+       width="16.309128"
+       height="10.48444"
+       x="83.308548"
+       y="-95.81778"
+       transform="scale(1,-1)" />
+    <image
+       y="85.333336"
+       x="103.98125"
+       id="image3844"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+    <image
+       y="98.5625"
+       x="83.34375"
+       id="image3918"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+    <image
+       y="111.79166"
+       x="83.34375"
+       id="image3929"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+    <image
+       y="125.02084"
+       x="83.34375"
+       id="image3940"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+    <image
+       y="138.25"
+       x="83.34375"
+       id="image3951"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="6.6145835"
+       width="16.404167" />
+    <image
+       y="125.02084"
+       x="104.51041"
+       id="image3962"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+    <image
+       y="111.79166"
+       x="104.51041"
+       id="image3973"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+    <image
+       y="98.5625"
+       x="103.98125"
+       id="image3984"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAAAoCAYAAACmTknCAAAABHNCSVQICAgIfAhkiAAAAGBJREFU
+aIHtz1ENgEAMwFAgCJiNTdisouKScwIu2Ef7FLRnd78HTGbuazpiiuM0jtM4TuM4jeM0jtM4TuM4
+jeM0jtM4TuM4jeM0jtM4TuM4jeM0jtNgx++qWtMRf4uI5wM9QgYwvRAAfQAAAABJRU5ErkJggg==
+"
+       preserveAspectRatio="none"
+       height="10.583333"
+       width="16.404167" />
+  </g>
+</svg>

--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
@@ -29,7 +29,7 @@ public class OSMObjInfoActions {
 
     public static void copyUser(String user) {
         if (!user.isEmpty()) {
-            String linkUser = "https://www.openstreetmap.org/user/" + user;
+            String linkUser = Config.getUrls().getBaseUserUrl().concat("/").concat(user);
             StringSelection selection = new StringSelection(linkUser);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             clipboard.setContents(selection, selection);
@@ -39,7 +39,7 @@ public class OSMObjInfoActions {
 
     public static void openinBrowserUser(String user) {
         if (!user.isEmpty()) {
-            openInBrowser("https://www.openstreetmap.org/user/".concat(user));
+            openInBrowser(Config.getUrls().getBaseUserUrl().concat("/").concat(user));
         }
 
     }
@@ -58,7 +58,7 @@ public class OSMObjInfoActions {
 
     public static void copyChangeset(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            String linkchangeset = "https://www.openstreetmap.org/changeset/".concat(idChangeset);
+            String linkchangeset = Config.getUrls().getBaseBrowseUrl().concat("/changeset/").concat(idChangeset);
             StringSelection selection = new StringSelection(linkchangeset);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             clipboard.setContents(selection, selection);
@@ -68,7 +68,7 @@ public class OSMObjInfoActions {
 
     public static void openinBrowserChangeset(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            openInBrowser("https://www.openstreetmap.org/changeset/".concat(idChangeset));
+            openInBrowser(Config.getUrls().getBaseBrowseUrl().concat("/changeset/").concat(idChangeset));
         }
     }
 
@@ -83,8 +83,8 @@ public class OSMObjInfoActions {
         String linkobjid = "";
         StringBuilder builder = new StringBuilder();
         for (AllOsmObjInfo object : osmObjInfo) {
-            builder.append("https://www.openstreetmap.org/")
-                .append(object.typeObj).append("/").append(object.idObject);
+            builder.append(Config.getUrls().getBaseBrowseUrl()).append('/')
+                .append(object.typeObj).append('/').append(object.idObject);
             if (osmObjInfo.indexOf(object) < osmObjInfo.size() - 2) {
                 builder.append(", ");
             }
@@ -149,7 +149,7 @@ public class OSMObjInfoActions {
             return;
         for (AllOsmObjInfo info : osmObjInfo) {
             if (info.typeObj != null && !info.idObject.isEmpty()) {
-                openInBrowser("https://www.openstreetmap.org/" + info.typeObj + "/" + info.idObject);
+                openInBrowser(Config.getUrls().getBaseBrowseUrl().concat("/").concat(info.typeObj).concat("/").concat(info.idObject));
             }
         }
     }

--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
@@ -74,7 +74,7 @@ public class OSMObjInfoActions {
 
     public static void openinBrowserChangesetMap(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            openInBrowser("https://osmcha.mapbox.com/".concat(idChangeset));
+            openInBrowser("https://osmcha.org/".concat(idChangeset));
         }
     }
 

--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
@@ -52,7 +52,7 @@ public class OSMObjInfoActions {
 
     static void openinBrowserUserOsmComments(String user) {
         if (!user.isEmpty()) {
-            openInBrowser("https://www.mapbox.com/osm-comments/#/changesets/?q=users:".concat(user));
+            openInBrowser("https://resultmaps.neis-one.org/osm-discussion-comments?commented&user=".concat(user));
         }
     }
 

--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoActions.java
@@ -1,11 +1,23 @@
 package org.openstreetmap.josm.plugins.osmobjinfo;
 
+import static org.openstreetmap.josm.tools.I18n.marktr;
+import static org.openstreetmap.josm.tools.I18n.tr;
+
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
+import java.net.UnknownHostException;
+import java.util.List;
+
 import javax.swing.JOptionPane;
+
+import org.openstreetmap.josm.data.Bounds;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.Notification;
-import static org.openstreetmap.josm.tools.I18n.tr;
+import org.openstreetmap.josm.io.remotecontrol.RemoteControl;
+import org.openstreetmap.josm.io.remotecontrol.handler.LoadAndZoomHandler;
+import org.openstreetmap.josm.plugins.osmobjinfo.OSMObjInfotDialog.AllOsmObjInfo;
+import org.openstreetmap.josm.spi.preferences.Config;
 import org.openstreetmap.josm.tools.OpenBrowser;
 
 /**
@@ -13,6 +25,7 @@ import org.openstreetmap.josm.tools.OpenBrowser;
  * @author ruben
  */
 public class OSMObjInfoActions {
+    public static final String COPY = marktr("Copy: {0}");
 
     public static void copyUser(String user) {
         if (!user.isEmpty()) {
@@ -20,7 +33,7 @@ public class OSMObjInfoActions {
             StringSelection selection = new StringSelection(linkUser);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             clipboard.setContents(selection, selection);
-            new Notification(tr("Copy: " + linkUser)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            new Notification(tr(COPY, linkUser)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
         }
     }
 
@@ -39,17 +52,17 @@ public class OSMObjInfoActions {
 
     static void openinBrowserUserOsmComments(String user) {
         if (!user.isEmpty()) {
-            openInBrowser( "https://www.mapbox.com/osm-comments/#/changesets/?q=users:".concat(user));
+            openInBrowser("https://www.mapbox.com/osm-comments/#/changesets/?q=users:".concat(user));
         }
     }
 
     public static void copyChangeset(String idChangeset) {
         if (!idChangeset.isEmpty()) {
-            String linkchangeset = "https://www.openstreetmap.org/changeset/" + idChangeset;
+            String linkchangeset = "https://www.openstreetmap.org/changeset/".concat(idChangeset);
             StringSelection selection = new StringSelection(linkchangeset);
             Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
             clipboard.setContents(selection, selection);
-            new Notification(tr("Copy: " + linkchangeset)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+            new Notification(tr(COPY, linkchangeset)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
         }
     }
 
@@ -65,25 +78,89 @@ public class OSMObjInfoActions {
         }
     }
 
-    public static void copyIdobj(String typeObj, String idobj) {
-        if (typeObj != null && !idobj.isEmpty()) {
-            String linkobjid = "https://www.openstreetmap.org/" + typeObj + "/" + idobj;
-            StringSelection selection = new StringSelection(linkobjid);
-            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(selection, selection);
-            new Notification(tr("Copy: " + linkobjid)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+    public static void copyIdobj(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo == null || osmObjInfo.isEmpty()) return;
+        String linkobjid = "";
+        StringBuilder builder = new StringBuilder();
+        for (AllOsmObjInfo object : osmObjInfo) {
+            builder.append("https://www.openstreetmap.org/")
+                .append(object.typeObj).append("/").append(object.idObject);
+            if (osmObjInfo.indexOf(object) < osmObjInfo.size() - 2) {
+                builder.append(", ");
+            }
+            if (osmObjInfo.indexOf(object) == osmObjInfo.size() - 2) {
+                if (osmObjInfo.size() == 2) {
+                    builder.append(" ");
+                } else {
+                    builder.append(", ");
+                }
+                builder.append(tr("and"));
+                builder.append(" ");
+            }
+        }
+        linkobjid = builder.toString();
+        StringSelection selection = new StringSelection(linkobjid);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(selection, selection);
+        new Notification(tr(COPY, linkobjid)).setIcon(JOptionPane.INFORMATION_MESSAGE).setDuration(Notification.TIME_SHORT).show();
+    }
+
+    public static void copyRemoteControl(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo == null)
+            return;
+        StringBuilder builder = new StringBuilder();
+        try {
+            builder.append("http://");
+            builder.append(RemoteControl.getInet4Address().getHostAddress());
+            builder.append(":");
+            builder.append(Config.getPref().getInt("remote.control.port", 8111));
+        } catch (UnknownHostException e) {
+            // Append the default remote control address (this gets thrown at RemoteControl#getInet4Address)
+            builder.append("127.0.0.1:8111");
+        }
+        builder.append("/").append(LoadAndZoomHandler.command).append("?");
+        if (!osmObjInfo.isEmpty())
+            builder.append("select=");
+        for (int i = 0; i < osmObjInfo.size(); i++) {
+            AllOsmObjInfo object = osmObjInfo.get(i);
+            builder.append(object.typeObj);
+            builder.append(object.idObject);
+            if (i < osmObjInfo.size() - 1)
+                builder.append(',');
+        }
+        Bounds viewPortBound = MainApplication.getMap().mapView
+                .getLatLonBounds(MainApplication.getMap().mapView.getVisibleRect());
+        // We don't need to check that the length is > 0, as we have the remote control URL
+        if (builder.charAt(builder.length() - 1) != '?') {
+            builder.append('&');
+        }
+        builder.append("left=").append(viewPortBound.getMinLon()).append("&right=").append(viewPortBound.getMaxLon())
+                .append("&top=").append(viewPortBound.getMaxLat()).append("&bottom=").append(viewPortBound.getMinLat());
+        String remoteControl = builder.toString();
+        StringSelection selection = new StringSelection(remoteControl);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(selection, selection);
+        new Notification(tr(COPY, remoteControl)).setIcon(JOptionPane.INFORMATION_MESSAGE)
+          .setDuration(Notification.TIME_SHORT).show();
+    }
+
+    public static void openinBrowserIdobj(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo.size() > OSMObjInfoPlugin.MAXIMUM_SELECTION.get() || osmObjInfo.isEmpty())
+            return;
+        for (AllOsmObjInfo info : osmObjInfo) {
+            if (info.typeObj != null && !info.idObject.isEmpty()) {
+                openInBrowser("https://www.openstreetmap.org/" + info.typeObj + "/" + info.idObject);
+            }
         }
     }
 
-    public static void openinBrowserIdobj(String typeObj, String idobj) {
-        if (typeObj != null && !idobj.isEmpty()) {
-            openInBrowser("https://www.openstreetmap.org/" + typeObj + "/" + idobj);
-        }
-    }
-
-    public static void openinBrowserIdobjOsmDeepHistory(String typeObj, String idobj) {
-        if (typeObj != null && !idobj.isEmpty()) {
-            openInBrowser("https://osmlab.github.io/osm-deep-history/#/" + typeObj + "/" + idobj);
+    public static void openinBrowserIdobjOsmDeepHistory(List<AllOsmObjInfo> osmObjInfo) {
+        if (osmObjInfo.size() > OSMObjInfoPlugin.MAXIMUM_SELECTION.get() || osmObjInfo.isEmpty())
+            return;
+        for (AllOsmObjInfo info : osmObjInfo) {
+            if (info.typeObj != null && !info.idObject.isEmpty()) {
+                openInBrowser("http://osmlab.github.io/osm-deep-history/#/" + info.typeObj + "/" + info.idObject);
+            }
         }
     }
 

--- a/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/osmobjinfo/OSMObjInfoPlugin.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.josm.plugins.osmobjinfo;
 
 import java.awt.GraphicsEnvironment;
+
+import org.openstreetmap.josm.data.preferences.IntegerProperty;
 import org.openstreetmap.josm.gui.MapFrame;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
@@ -10,6 +12,9 @@ import org.openstreetmap.josm.plugins.PluginInformation;
  * @author ruben
  */
 public class OSMObjInfoPlugin extends Plugin {
+
+    /** The maximum number of objects to allow to be used in group selections. */
+    public static final IntegerProperty MAXIMUM_SELECTION = new IntegerProperty("osm-obj-info.maximum-selection", 5);
 
     protected static OSMObjInfotDialog objInfotDialog;
 


### PR DESCRIPTION
…, but just zooms to area)

Signed-off-by: Taylor Smock <taylor.smock@kaart.com>


----

It would be nice to have a feature that copies a remote control URL for the objects in the viewport and the viewport itself. This should make it slightly easier to point someone at a specific area with respect to an object.